### PR TITLE
rebar.config updates for rebar3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ ebin/
 c_src/*.o
 priv/
 c_src/dummy/
+/_build
+/rebar.lock
+

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,19 @@
 %% -*- mode: erlang;erlang-indent-level: 2;indent-tabs-mode: nil -*-
 {erl_opts, [debug_info]}.
 
+{plugins, [
+           {pc, "1.2.0"}
+          ]}.
+
+{provider_hooks,
+ [{pre,
+   [
+    {compile, {pc, compile}},
+    {clean, {pc, clean}}
+   ]
+  }]
+}.
+
 {port_specs,
  [{"linux|darwin", "priv/scrypt_nif.so",
    ["c_src/scrypt_nif.cpp", "c_src/scrypt.cpp",

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,0 +1,8 @@
+%% -*- mode: erlang; -*-
+case erlang:function_exported(rebar3, main, 1) of
+    true -> % rebar3
+        CONFIG;
+    false -> % rebar 2.x or older
+        %% remove plugins and provider_hooks, which are rebar3 things
+        lists:keydelete(provider_hooks, 1, lists:keydelete(plugins, 1, CONFIG))
+end.


### PR DESCRIPTION
Moving from K2InformaticsGmbH/erlscrypt#2

Adds the port-compiler plug-in so that rebar3 knows what to do with
the code.